### PR TITLE
Visualization ui

### DIFF
--- a/proteus-spring-dashboard/src/app/pages/visualizations/VisualizationForm.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/VisualizationForm.ts
@@ -57,6 +57,14 @@ export abstract class VisualizationForm implements OnInit, OnDestroy {
         FormVisualization.calculationsCbChange(event);
     }
 
+    protected chartsWithAnnotations() {
+      return ['Linechart', 'Scatterplot', 'Barchart'];
+    }
+
+    protected chartsWithStatistics() {
+      return ['Linechart'];
+    }
+
     public ngOnInit() {
         this._createForm();
 

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.html
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.html
@@ -18,7 +18,6 @@
       <select id="annotationType" class="formControl" [(ngModel)]="newAnnotation.type">
       <option value="threshold">Threshold</option>
       <option value="band">Band</option>
-      <option value="region">Region</option>
     </select>
     </div>
   </div>

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html
@@ -92,24 +92,27 @@
       </div>
     </ba-card>
 
-    <table class="form-group-table">
-        <tbody>
-            <tr *ngFor="let chart of chartsWithAnnotations()">
-                <td *ngIf="form.controls.type.value == chart">
-                    <ba-card class="smart-table-container" title="visualization.annotations.title">
-                      <app-annotations></app-annotations>
-                    </ba-card>
-                </td>
-            </tr>
-            <tr *ngFor="let chart of chartsWithStatistics()">
-                <td *ngIf="form.controls.type.value == chart">
-                    <ba-card class="smart-table-container" title="visualization.statistics.title">
-                      <app-statistics></app-statistics>
-                    </ba-card>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+    <div class="col">
+      <table class="form-group-table">
+          <tbody>
+              <tr *ngFor="let chart of chartsWithAnnotations()">
+                  <td *ngIf="form.controls.type.value == chart">
+                      <ba-card class="smart-table-container" title="visualization.annotations.title">
+                        <app-annotations></app-annotations>
+                      </ba-card>
+                  </td>
+              </tr>
+              <tr *ngFor="let chart of chartsWithStatistics()">
+                  <td *ngIf="form.controls.type.value == chart">
+                      <ba-card class="smart-table-container" title="visualization.statistics.title">
+                        <app-statistics></app-statistics>
+                      </ba-card>
+                  </td>
+              </tr>
+          </tbody>
+      </table>
+    </div>
+
   </div>
 
 

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html
@@ -86,7 +86,7 @@
       </div>
     </ba-card>
 
-    <table class="form-group-table">
+    <table *ngIf="form.controls.type.value=='Linechart'; else blank" class="form-group-table">
         <tbody>
             <tr>
                 <td>
@@ -105,6 +105,9 @@
         </tbody>
     </table>
 
+    <ng-template #blank>
+      <div class="col"></div>
+    </ng-template>
   </div>
 
 

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html
@@ -1,17 +1,7 @@
 <form [formGroup]="form" novalidate (ngSubmit)="save(form.value, form.valid)" class="form-horizontal">
 
   <div class="row">
-    <ba-card class="col" title="visualization.mode">
-      <label for="coilSelection"><strong>Select your prefered coil ID:</strong></label>
-      <select id="coilSelection" class="form-control" formControlName="coilID">
-        <option value="current">Current coil (streaming)</option>
-        <option value="40101001">40101001</option>
-        <option value="40101002">40101002</option>
-        <option value="40101003">40101003</option>
-        <option value="40101006">40101006</option>
 
-      </select>
-    </ba-card>
   </div>
 
   <div class="row">
@@ -33,17 +23,33 @@
   </div>
 
   <div class="row">
+      <ba-card class="col" title="visualization.mode">
+        <label for="coilSelection"><strong>Select your prefered coil ID:</strong></label>
+        <select id="coilSelection" class="form-control" formControlName="coilID">
+          <option value="current">Current coil (streaming)</option>
+          <option value="40101001">40101001</option>
+          <option value="40101002">40101002</option>
+          <option value="40101003">40101003</option>
+          <option value="40101006">40101006</option>
+        </select>
+      </ba-card>
+
     <ba-card class="col"  title="Real-time data">
-      <label for="varSelect"><strong>Select your var ID:</strong></label>
-      <select id="varSelect" class="form-control" formControlName="variable" name="variable">
-        <option *ngFor="let v of variables" [value]="v">{{v}}</option>
-      </select>
+      <div class="row">
+        <div class="col">
+          <label for="varSelect"><strong>Select your var ID:</strong></label>
+          <select id="varSelect" class="form-control" formControlName="variable" name="variable">
+            <option *ngFor="let v of variables" [value]="v">{{v}}</option>
+          </select>
+        </div>
 
-      <label><strong>Calculations:</strong></label>
-
-      <select class="form-control" formControlName="calculations" multiple>
-        <option *ngFor="let c of calculations" [value]="c">{{c.label}}</option>
-      </select>
+        <div class="col">
+          <label><strong>Calculations:</strong></label>
+          <select class="form-control" formControlName="calculations" multiple>
+            <option *ngFor="let c of calculations" [value]="c">{{c.label}}</option>
+          </select>
+        </div>
+      </div>
     </ba-card>
   </div>
 
@@ -86,17 +92,17 @@
       </div>
     </ba-card>
 
-    <table *ngIf="form.controls.type.value=='Linechart'; else blank" class="form-group-table">
+    <table class="form-group-table">
         <tbody>
-            <tr>
-                <td>
+            <tr *ngFor="let chart of chartsWithAnnotations()">
+                <td *ngIf="form.controls.type.value == chart">
                     <ba-card class="smart-table-container" title="visualization.annotations.title">
                       <app-annotations></app-annotations>
                     </ba-card>
                 </td>
             </tr>
-            <tr>
-                <td>
+            <tr *ngFor="let chart of chartsWithStatistics()">
+                <td *ngIf="form.controls.type.value == chart">
                     <ba-card class="smart-table-container" title="visualization.statistics.title">
                       <app-statistics></app-statistics>
                     </ba-card>
@@ -104,10 +110,6 @@
             </tr>
         </tbody>
     </table>
-
-    <ng-template #blank>
-      <div class="col"></div>
-    </ng-template>
   </div>
 
 

--- a/proteus-spring-dashboard/src/app/pages/visualizations/form-visualization.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/form-visualization.ts
@@ -18,8 +18,7 @@ export class FormVisualization {
 
     if (event.target.checked) {
       this.selectedCalculations.push(event.target.value);
-    }
-    else {
+    } else {
       let index = this.selectedCalculations.indexOf(event.target.value);
       if (index > -1) {
           this.selectedCalculations.splice(index, 1);
@@ -37,13 +36,14 @@ export class FormVisualization {
       variable: [model ? model.variable : null],
       calculations: [model ? model.calculations : null, [<any>Validators.required]],
       alarms: [model ? model.alarms : null],
-      coilID: [model ? model.coilID : 'current']
+      coilID: [model ? model.coilID : 'current'],
      // alarmFactor: [model ? model.alarmFactor : 1]
     });
   }
 
   /**
-   * Function that creates configuration menu on Visualization board by chart property
+   * @method
+   * It creates configuration menu on Visualization board by chart property
    * (New-visualization): Basically, default config values get from proteic defaults configuration
    * (Edit-visualization): Create configuration form with user-input config values. If no user-input values,
    * config values get from only proteic defaults
@@ -56,7 +56,7 @@ export class FormVisualization {
       conf = null,
       defaults,
       // default values for new-visualization (different from its value in proteic)
-      proteusWebDefaults = {'pauseButton': true, 'propertyY': 'value'};
+      proteusWebDefaults = { 'propertyY': 'value' };
 
     if (model) {
       FormVisualization.defaults = getDefaultOptions(model.type.toLowerCase());
@@ -67,16 +67,14 @@ export class FormVisualization {
       if (FormVisualization.defaults.hasOwnProperty(property)) {
         if (property in proteusWebDefaults) {
           defaults = proteusWebDefaults[property];
-        }
-        else {
+        } else {
           defaults = FormVisualization.defaults[property];
         }
 
         // Edit-visualization: If proteic chart defaults add, generated chart configuration should be updated
         if (conf) {
           form[property] = [conf[property] ? conf[property] : FormVisualization.defaults[property]];
-        }
-        else { // New-visualization
+        } else { // New-visualization
           form[property] = [defaults];
         }
       }

--- a/proteus-spring-dashboard/src/app/theme/sass/_form.scss
+++ b/proteus-spring-dashboard/src/app/theme/sass/_form.scss
@@ -72,7 +72,7 @@
 }
 
 table.form-group-table{
-    width: 50%;
+    width: 100%;
 }
 
 select.form-control {


### PR DESCRIPTION
#### What's this PR do?

1. Remove 'region' option in annotations. (It can't be implemented in proteic.js)
2. Divide 'visualization-mode' and 'real-time data card' width into half
3. In create-visualization, add chart condition for annotations and statistics menu
4. Align annotations and statistics menu with other cards' width   

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

---
> Thank you! :heart:

:rocket:

