### PR TITLE
Visualization active page title

### DIFF
--- a/proteus-spring-dashboard/src/app/pages/pages.menu.ts
+++ b/proteus-spring-dashboard/src/app/pages/pages.menu.ts
@@ -10,9 +10,10 @@ export const PAGES_MENU = [
             icon: 'ion-speedometer',
             selected: false,
             expanded: false,
-            order: 0
-          }
-        }
+            order: 0,
+            pathMatch: 'full',
+          },
+        },
       },
       {
         path: 'visualizations',
@@ -23,7 +24,8 @@ export const PAGES_MENU = [
             selected: false,
             expanded: false,
             order: 100,
-          }
+            pathMatch: 'full',
+          },
         },
         children: [
           {
@@ -31,6 +33,7 @@ export const PAGES_MENU = [
             data: {
               menu: {
                 title: 'Create visualization',
+                pathMatch: 'full',
               },
             },
           },
@@ -41,7 +44,7 @@ export const PAGES_MENU = [
                 title: 'Edit visualization',
               },
             },
-          }
+          },
           // {
           //   path: 'ckeditor',
           //   data: {
@@ -50,7 +53,7 @@ export const PAGES_MENU = [
           //     }
           //   }
           // }
-        ]
+        ],
       },
        {
         path: 'historical',
@@ -60,9 +63,10 @@ export const PAGES_MENU = [
             icon: 'ion-arrow-graph-up-left',
             selected: false,
             expanded: false,
-            order: 0
-          }
-        }
+            order: 0,
+            pathMatch: 'full',
+          },
+        },
       },
       {
         path: '',
@@ -72,9 +76,10 @@ export const PAGES_MENU = [
             url: 'https://www.proteus-bigdata.com/',
             icon: 'ion-information-circled',
             order: 800,
-            target: '_blank'
-          }
-        }
+            target: '_blank',
+            pathMatch: 'full',
+          },
+        },
       },
       {
         path: '',
@@ -84,10 +89,11 @@ export const PAGES_MENU = [
             url: 'https://github.com/proteus-h2020/',
             icon: 'ion-social-github',
             order: 800,
-            target: '_blank'
-          }
-        }
-      }
+            target: '_blank',
+            pathMatch: 'full',
+          },
+        },
+      },
       // {
       //   path: 'components',
       //   data: {
@@ -389,6 +395,6 @@ export const PAGES_MENU = [
       //     }
       //   ]
       // },
-    ]
-  }
+    ],
+  },
 ];

--- a/proteus-spring-dashboard/src/app/pages/pages.menu.ts
+++ b/proteus-spring-dashboard/src/app/pages/pages.menu.ts
@@ -6,7 +6,7 @@ export const PAGES_MENU = [
         path: 'dashboard',
         data: {
           menu: {
-            title: 'general.menu.dashboard',
+            title: 'Dashboard',
             icon: 'ion-speedometer',
             selected: false,
             expanded: false,
@@ -56,7 +56,7 @@ export const PAGES_MENU = [
         path: 'historical',
         data: {
           menu: {
-            title: 'general.menu.historical',
+            title: 'Historical data',
             icon: 'ion-arrow-graph-up-left',
             selected: false,
             expanded: false,

--- a/proteus-spring-dashboard/src/app/pages/pages.menu.ts
+++ b/proteus-spring-dashboard/src/app/pages/pages.menu.ts
@@ -6,7 +6,7 @@ export const PAGES_MENU = [
         path: 'dashboard',
         data: {
           menu: {
-            title: 'Dashboard',
+            title: 'general.menu.dashboard',
             icon: 'ion-speedometer',
             selected: false,
             expanded: false,
@@ -32,7 +32,7 @@ export const PAGES_MENU = [
             path: 'new',
             data: {
               menu: {
-                title: 'Create visualization',
+                title: 'general.menu.create',
                 pathMatch: 'full',
               },
             },
@@ -41,7 +41,7 @@ export const PAGES_MENU = [
             path: 'edit',
             data: {
               menu: {
-                title: 'Edit visualization',
+                title: 'general.menu.edit',
               },
             },
           },
@@ -59,7 +59,7 @@ export const PAGES_MENU = [
         path: 'historical',
         data: {
           menu: {
-            title: 'Historical data',
+            title: 'general.menu.historical',
             icon: 'ion-arrow-graph-up-left',
             selected: false,
             expanded: false,

--- a/proteus-spring-dashboard/src/app/theme/services/baMenu/baMenu.service.ts
+++ b/proteus-spring-dashboard/src/app/theme/services/baMenu/baMenu.service.ts
@@ -10,31 +10,32 @@ export class BaMenuService {
 
   protected _currentMenuItem = {};
 
-  constructor(private _router:Router) { }
+  constructor(private _router: Router) { }
 
   /**
    * Updates the routes in the menu
    *
    * @param {Routes} routes Type compatible with app.menu.ts
+   * @see page.component.ts
    */
   public updateMenuByRoutes(routes: Routes) {
     let convertedRoutes = this.convertRoutesToMenus(_.cloneDeep(routes));
     this.menuItems.next(convertedRoutes);
   }
 
-  public convertRoutesToMenus(routes:Routes):any[] {
+  public convertRoutesToMenus(routes: Routes): any[] {
     let items = this._convertArrayToItems(routes);
     return this._skipEmpty(items);
   }
 
-  public getCurrentItem():any {
+  public getCurrentItem(): any {
     return this._currentMenuItem;
   }
 
-  public selectMenuItem(menuItems:any[]):any[] {
+  public selectMenuItem(menuItems: any[]): any[] {
     let items = [];
     menuItems.forEach((item) => {
-      this._selectItem(item);
+      this._selectItemByRoute(item);
 
       if (item.selected) {
         this._currentMenuItem = item;
@@ -48,7 +49,7 @@ export class BaMenuService {
     return items;
   }
 
-  protected _skipEmpty(items:any[]):any[] {
+  protected _skipEmpty(items: any[]): any[] {
     let menu = [];
     items.forEach((item) => {
       let menuItem;
@@ -68,7 +69,7 @@ export class BaMenuService {
     return [].concat.apply([], menu);
   }
 
-  protected _convertArrayToItems(routes:any[], parent?:any):any[] {
+  protected _convertArrayToItems(routes: any[], parent?: any): any[] {
     let items = [];
     routes.forEach((route) => {
       items.push(this._convertObjectToItem(route, parent));
@@ -76,8 +77,8 @@ export class BaMenuService {
     return items;
   }
 
-  protected _convertObjectToItem(object, parent?:any):any {
-    let item:any = {};
+  protected _convertObjectToItem(object, parent?: any): any {
+    let item: any = {};
     if (object.data && object.data.menu) {
       // this is a menu object
       item = object.data.menu;
@@ -110,18 +111,23 @@ export class BaMenuService {
     return prepared;
   }
 
-  protected _prepareItem(object:any):any {
+  protected _prepareItem(object: any): any {
     if (!object.skip) {
       object.target = object.target || '';
-      object.pathMatch = object.pathMatch  || 'full';
-      return this._selectItem(object);
+      return this._selectItemByRoute(object);
     }
 
     return object;
   }
 
-  protected _selectItem(object:any):any {
-    object.selected = this._router.isActive(this._router.createUrlTree(object.route.paths), object.pathMatch === 'full');
+  /**
+   * Select menu item by current route paths
+   * @protected
+   * @memberof BaMenuService
+   */
+  protected _selectItemByRoute(object: any): any {
+    let exact: boolean = object.pathMatch === 'full';
+    object.selected = this._router.isActive(this._router.createUrlTree(object.route.paths), exact);
     return object;
   }
 }

--- a/proteus-spring-dashboard/src/assets/i18n/US/en.json
+++ b/proteus-spring-dashboard/src/assets/i18n/US/en.json
@@ -22,6 +22,8 @@
       "proteus_gh_link": "Proteus repository",
       "dashboard": "Dashboard",
       "visualizations": "Visualizations",
+      "create": "Create visualizations",
+      "edit": "Edit visualizations",
       "historical": "Historical data",
       "editors": "Editors",
       "ck_editor": "CKEditor",


### PR DESCRIPTION
#### What's this PR do?

existing Issue: 
1. On create or edit visualization page, if user input confirm button, 
activePage title(located in top of page) happens 'general.menu.dashboard' or 'general.menu.historical'

2. On dashboard, if user input edit icon and page changes edit-visualization, title is just 'dashboard'
-> pathMatch problem (route paths like 'edit/:id' can't be matched if pathMatch is 'full')

this PR solved the issue 

#### Where should the reviewer start?

#### How should this be manually tested?
On create or edit visualization page, click confirm button (after creating or editing chart)
On dashboard, click edit icon on right part of chart 

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

---
> Thank you! :heart:

:rocket:

