### PR TITLE
Components improve

### DIFF
--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.ts
@@ -26,6 +26,9 @@ export class AnnotationsComponent implements OnInit {
 
   ngOnInit(): void {
     this.id = this.id ? this.id : null; // If id exists, page is edit-visualization
+    if (!this.id) {
+      this.componentsService.initialize();
+    }
 
     this.showAnnotations(this.id);
   }

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Annotation, AnnotationTypes } from './annotation';
 import { ComponentsService } from '../components.service';
 import { ComponentSet } from '../componentSet';
@@ -8,7 +8,7 @@ import { ActivatedRoute } from '@angular/router';
   templateUrl: './annotations.component.html',
   styleUrls: ['./annotations.component.scss']
 })
-export class AnnotationsComponent implements OnInit {
+export class AnnotationsComponent implements OnInit, OnDestroy {
 
   selectedAnnotation: Annotation;
   newAnnotation: Annotation;
@@ -26,9 +26,6 @@ export class AnnotationsComponent implements OnInit {
 
   ngOnInit(): void {
     this.id = this.id ? this.id : null; // If id exists, page is edit-visualization
-    if (!this.id) {
-      this.componentsService.initialize();
-    }
 
     this.showAnnotations(this.id);
   }
@@ -70,4 +67,7 @@ export class AnnotationsComponent implements OnInit {
     this.newAnnotation = new Annotation();
   }
 
+  ngOnDestroy() {
+    this.componentsService.initialize();
+  }
 }

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.ts
@@ -2,8 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Annotation, AnnotationTypes } from './annotation';
 import { ComponentsService } from '../components.service';
 import { ComponentSet } from '../componentSet';
-import { Router, ActivatedRoute } from '@angular/router';
-
+import { ActivatedRoute } from '@angular/router';
 @Component({
   selector: 'app-annotations',
   templateUrl: './annotations.component.html',
@@ -16,18 +15,19 @@ export class AnnotationsComponent implements OnInit {
   annotations: Annotation[];
   annotationId: number = 1;
 
+  private id: number = null;
+
   constructor(
     private componentsService: ComponentsService,
-    private route: Router,
-  ) { }
+    private route: ActivatedRoute,
+  ) {
+    this.route.params.subscribe(params => { this.id = parseInt(params['id']); });
+  }
 
   ngOnInit(): void {
-    let id;
-    if (this.route.url != '/pages/visualizations/new') { // edit
-      id = +this.route.url.split('/').pop();
-    }
+    this.id = this.id ? this.id : null; // If id exists, page is edit-visualization
 
-    this.showAnnotations(id);
+    this.showAnnotations(this.id);
   }
 
   showAnnotations(id: number = null): void {

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/components.service.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/components.service.ts
@@ -37,6 +37,16 @@ export class ComponentsService {
     this.components = new Array<ComponentSet>();
   }
 
+  /**
+   * @method
+   * Initialize components config in create-visualization
+   * by fitlering remaining components config of uncreated chart
+   * @memberof ComponentsService
+   */
+  public initialize() {
+    this.components = this.components.filter((component) => component.chartId != null);
+  }
+
   public getComponents(id: number = null): Promise<ComponentSet> {
     let component;
     this.chartId = id;

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Statistics, StatisticsTypes } from './statistics';
 import { ComponentsService } from '../components.service';
 import { ComponentSet } from '../componentSet';
@@ -9,7 +9,7 @@ import { ActivatedRoute } from '@angular/router';
   templateUrl: './statistics.component.html',
   styleUrls: ['./statistics.component.scss']
 })
-export class StatisticsComponent implements OnInit {
+export class StatisticsComponent implements OnInit, OnDestroy {
 
   selectedStatistics: Statistics;
   newStatistics: Statistics;
@@ -27,9 +27,6 @@ export class StatisticsComponent implements OnInit {
 
   ngOnInit(): void {
     this.id = this.id ? this.id : null; // If id exists, page is edit-visualization
-    if (!this.id) {
-      this.componentsService.initialize();
-    }
 
     this.showStatistics(this.id);
   }
@@ -74,4 +71,7 @@ export class StatisticsComponent implements OnInit {
     this.newStatistics = new Statistics();
   }
 
+  ngOnDestroy() {
+    this.componentsService.initialize();
+  }
 }

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Statistics, StatisticsTypes } from './statistics';
 import { ComponentsService } from '../components.service';
 import { ComponentSet } from '../componentSet';
-import { Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-statistics',
@@ -16,18 +16,19 @@ export class StatisticsComponent implements OnInit {
   statistics: Statistics[];
   statisticsId: number = 1;
 
+  private id: number = null;
+
   constructor(
     private componentsService: ComponentsService,
-    private route: Router,
-  ) { }
+    private route: ActivatedRoute,
+  ) {
+    this.route.params.subscribe(params => { this.id = parseInt(params['id']); });
+  }
 
   ngOnInit(): void {
-    let id;
-    if (this.route.url != '/pages/visualizations/new') { // edit
-      id = +this.route.url.split('/').pop();
-    }
+    this.id = this.id ? this.id : null; // If id exists, page is edit-visualization
 
-    this.showStatistics(id);
+    this.showStatistics(this.id);
   }
 
   showStatistics(id: number = null): void {

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.ts
@@ -27,6 +27,9 @@ export class StatisticsComponent implements OnInit {
 
   ngOnInit(): void {
     this.id = this.id ? this.id : null; // If id exists, page is edit-visualization
+    if (!this.id) {
+      this.componentsService.initialize();
+    }
 
     this.showStatistics(this.id);
   }


### PR DESCRIPTION
#### What's this PR do?

existing issue:
If user config annotations or statistics on create-visualization page without creating and then re-enter the page, the components config still remain

This PR solves this issue by initializing components config of uncreated chart in ngOnDestroy

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

---
> Thank you! :heart:

:rocket:

