### PR TITLE
Calculation form improve

### DIFF
--- a/proteus-spring-dashboard/src/app/chart.service.ts
+++ b/proteus-spring-dashboard/src/app/chart.service.ts
@@ -1,7 +1,6 @@
 import { Annotation, AnnotationTypes } from './pages/visualizations/components/annotations/annotation';
 import { Statistics } from './pages/visualizations/components/statistics/statistics';
 import { ComponentSet } from './pages/visualizations/components/componentSet';
-import { Calculation } from './pages/visualizations/VisualizationForm';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subject } from 'rxjs/Subject';
 import { Injectable } from '@angular/core';
@@ -32,9 +31,9 @@ export class ChartService {
         s.variable = 'mean';
         s.confidence = 'stdDeviation';
 
-        let calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
-        calculations.push(new Calculation('mean', 'Mean'));
+        let calculations = new Array<string>();
+        calculations.push('raw');
+        calculations.push('mean');
 
         let components = new ComponentSet();
         // components.annotations.push(a);
@@ -65,8 +64,8 @@ export class ChartService {
         this.charts.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
+        calculations = new Array<string>();
+        calculations.push('raw');
 
         components = new ComponentSet();
         components.annotations.push(a);
@@ -118,9 +117,9 @@ export class ChartService {
         this.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
-        calculations.push(new Calculation('mean', 'Mean'));
+        calculations = new Array<string>();
+        calculations.push('raw');
+        calculations.push('mean');
 
         components = new ComponentSet();
         components.annotations.push(a);
@@ -148,9 +147,9 @@ export class ChartService {
 
         this.push(chart);
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
-        calculations.push(new Calculation('mean', 'Mean'));
+        calculations = new Array<string>();
+        calculations.push('raw');
+        calculations.push('mean');
 
         components = new ComponentSet();
         components.annotations.push(a);
@@ -179,8 +178,8 @@ export class ChartService {
         this.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
+        calculations = new Array<string>();
+        calculations.push('raw');
         endpoints = new Array<string>();
         endpoints.push('/topic/realtime/var/8');
 
@@ -224,9 +223,9 @@ export class ChartService {
         this.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
-        calculations.push(new Calculation('mean', 'Mean'));
+        calculations = new Array<string>();
+        calculations.push('raw');
+        calculations.push('mean');
 
         components = new ComponentSet();
         components.annotations.push(a);
@@ -255,9 +254,9 @@ export class ChartService {
         this.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
-        calculations.push(new Calculation('mean', 'Mean'));
+        calculations = new Array<string>();
+        calculations.push('raw');
+        calculations.push('mean');
 
         components = new ComponentSet();
         components.statistics.push(s);
@@ -286,9 +285,9 @@ export class ChartService {
         this.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
-        calculations.push(new Calculation('mean', 'Mean'));
+        calculations = new Array<string>();
+        calculations.push('raw');
+        calculations.push('mean');
 
         components = new ComponentSet();
         components.statistics.push(s);
@@ -317,9 +316,9 @@ export class ChartService {
         this.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
-        calculations.push(new Calculation('mean', 'Mean'));
+        calculations = new Array<string>();
+        calculations.push('raw');
+        calculations.push('mean');
 
         components = new ComponentSet();
         components.statistics.push(s);
@@ -348,8 +347,8 @@ export class ChartService {
         this.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
+        calculations = new Array<string>();
+        calculations.push('raw');
         endpoints = new Array<string>();
         endpoints.push('/topic/realtime/var/25');
 
@@ -394,9 +393,9 @@ export class ChartService {
         this.push(chart);
 
 
-        calculations = new Array<Calculation>();
-        calculations.push(new Calculation('raw', 'Raw'));
-        calculations.push(new Calculation('mean', 'Mean'));
+        calculations = new Array<string>();
+        calculations.push('raw');
+        calculations.push('mean');
 
         components = new ComponentSet();
         components.statistics.push(s);

--- a/proteus-spring-dashboard/src/app/pages/dashboard/proteic/proteic.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/dashboard/proteic/proteic.component.ts
@@ -158,8 +158,8 @@ export class Proteic implements OnInit, AfterViewInit, OnDestroy {
   private _calculateUnpivotArray(chart: RealtimeChart): string[] {
     const unpivot = new Array<string>();
     for (const calculation of this.chart.calculations) {
-      if (calculation.value !== 'raw') {
-        unpivot.push(calculation.value);
+      if (calculation !== 'raw') {
+        unpivot.push(calculation);
       }
     }
     return unpivot;

--- a/proteus-spring-dashboard/src/app/pages/visualizations/VisualizationForm.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/VisualizationForm.ts
@@ -4,7 +4,7 @@ import { RealtimeChart } from './../../realtime-chart';
 import { FormVisualization } from './form-visualization';
 import { FormGroup } from '@angular/forms';
 
-export class Calculation {
+class Calculation {
     value;
     label;
     constructor(value: string, label: string) {
@@ -21,7 +21,7 @@ export abstract class VisualizationForm implements OnInit, OnDestroy {
     calculations: Calculation[];
 
     private type: string = 'streaming'; //batch or streaming
-    
+
     constructor() {
 
     }

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/new/new.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/new/new.component.ts
@@ -10,7 +10,7 @@ import { Chart } from '../../../../chart.interface';
 import 'style-loader!./new.scss';
 import { Annotation } from '../../components/annotations/annotation';
 import { AnnotationsService } from '../../components/annotations/annotations.service';
-import { Calculation, VisualizationForm } from 'app/pages/visualizations/VisualizationForm';
+import { VisualizationForm } from 'app/pages/visualizations/VisualizationForm';
 import { Statistics } from '../../components/statistics/statistics';
 import { ComponentsService } from '../../components/components.service';
 import { ComponentSet } from '../../components/componentSet';
@@ -45,16 +45,17 @@ export class CreateVisualizationComponent extends VisualizationForm implements O
 
     if (model.calculations) {
       for (const calc of model.calculations) {
-        if (calc.value === 'raw') {
+        if (calc == 'raw') {
           endpoints.push('/topic/realtime/var/' + model.variable);
-        } else if (calc.value == 'mean' || calc.value == 'variance') {
+        }
+        if (calc == 'mean' || calc == 'variance') {
           endpoints.push('/topic/flink/var/' + model.variable);
         }
       }
     }
 
     endpoints = endpoints.filter(onlyUnique);
-    let coilID  = model.coilID;
+    let coilID = model.coilID;
     function createChart(components: ComponentSet) {
       model = new RealtimeChart(
         model.title,

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html
@@ -45,8 +45,8 @@
 
         <div class="col">
           <label><strong>Calculations:</strong></label>
-          <select class="form-control" formControlName="calculations" multiple>
-            <option *ngFor="let c of calculations" [value]="c">{{c.label}}</option>
+          <select multiple class="form-control" formControlName="calculations" name="calculations">
+            <option *ngFor="let c of calculations" [value]="c.value">{{c.label}}</option>
           </select>
         </div>
       </div>

--- a/proteus-spring-dashboard/src/app/realtime-chart.ts
+++ b/proteus-spring-dashboard/src/app/realtime-chart.ts
@@ -1,15 +1,14 @@
 import { Annotation } from './pages/visualizations/components/annotations/annotation';
-import { Calculation } from './pages/visualizations/VisualizationForm';
 import { ComponentSet } from './pages/visualizations/components/componentSet';
 
 export class RealtimeChart {
 
   public static N: number = 1;
   public id: number = 0;
-  public alarms : boolean = false;
-  public alarmFactor : number = 1;
-  public layout : string = '6';
-  public coilID : string = 'current';
+  public alarms: boolean = false;
+  public alarmFactor: number = 1;
+  public layout: string = '6';
+  public coilID: string = 'current';
 
   constructor(
     public title: string,
@@ -17,7 +16,7 @@ export class RealtimeChart {
     public configuration: any,
     public components: ComponentSet,
     public variable: string,
-    public calculations: Calculation[],
+    public calculations: string[],
     public endpoints: string[],
   ) {
     this.id = RealtimeChart.N++;


### PR DESCRIPTION
#### What's this PR do?

existing issue:
 If user click edit button, and page is on edit-visualization, configured calculation highlight is not shown.

This PR solved this issue and code becomes more simple
(label in calculation class is only used to create form html, it is not relative to create chart) 

#### Where should the reviewer start?
 proteus-spring-dashboard/src/app/pages/visualizations/components/visualization-form.html

#### How should this be manually tested?
click edit button of chart on dashboard 

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

---
> Thank you! :heart:

:rocket:

