### PR TITLE
Add detail configuration window on Annotations and  Statistics config UI

### DIFF
--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.html
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.html
@@ -19,7 +19,9 @@
       <option value="threshold">Threshold</option>
       <option value="band">Band</option>
     </select>
-      <p class="form-text small-text" *ngIf="newAnnotation.type == 'band'">Band annotation can be used in Linechart.</p>
+    </div>
+    <div class="col-7">
+      <p id="bandNotice" class="form-text small-text" *ngIf="newAnnotation.type == 'band'">Band annotation can be used in Linechart.</p>
     </div>
   </div>
   <div class="form-group row" *ngIf="newAnnotation.type == 'threshold'">
@@ -63,6 +65,7 @@
     <tr>
       <th>Text</th>
       <th>Type</th>
+      <th>Detail</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -71,6 +74,9 @@
       <td>{{annotation.text}}</td>
       <td>{{annotation.type}}</td>
       <td>
+        <a href="#" (click)="showConfiguration(annotation); false">Show</a>
+      </td>
+      <td>
         <a href="#" (click)="edit(annotation); false">Edit</a>
         <a href="#" (click)="delete(annotation); false">Delete</a>
       </td>
@@ -78,7 +84,7 @@
   </tbody>
 </table>
 
-<div *ngIf="selectedAnnotation">
+<div *ngIf="selectedAnnotation && editConfig==true">
   <div class="form-group">
     <h3>Edit annotation</h3>
   </div>
@@ -123,5 +129,58 @@
   <div class="form-group right-col">
     <button class="btn btn-col" (click)="update(selectedAnnotation)">Save</button>
     <button class="btn btn-col" (click)="cancel()">Cancel</button>
+  </div>
+</div>
+
+<div *ngIf="selectedAnnotation && editConfig==false">
+  <div class="form-group">
+    <h3>Configuration</h3>
+  </div>
+
+  <div class="form-group row">
+    <label for="annotationText" class="col-2 col-form-label">Text</label>
+    <div class="col-10">
+      <div class="form-control">{{selectedAnnotation.text}}</div>
+    </div>
+  </div>
+  <div class="form-group row">
+    <label for="annotationType" class="col-2 col-form-label">Type</label>
+    <div class="col-3">
+      <div class="form-control">{{selectedAnnotation.type}}</div>
+    </div>
+    <div class="col-7">
+      <p id="bandNotice" class="form-text small-text" *ngIf="selectedAnnotation.type == 'band'">Band annotation can be used in Linechart.</p>
+    </div>
+  </div>
+  <div class="form-group row" *ngIf="selectedAnnotation.type == 'threshold'">
+    <label for="annotationAxis" class="col-2  col-form-label">Axis</label>
+    <div class="col-2">
+      <div class="form-control" id="annotationAxis">{{selectedAnnotation.axis}}</div>
+    </div>
+  </div>
+  <div class="form-group row" *ngIf="selectedAnnotation.type == 'threshold' && !selectedAnnotation.variable">
+    <label class="col-2  col-form-label" for="annotationValue">Value </label>
+    <div class="col-9">
+      <div class="form-control">{{selectedAnnotation.value}}</div>
+      <p class="form-text small-text">Value for a static annotation.</p>
+    </div>
+  </div>
+  <div class="form-group row" *ngIf="selectedAnnotation.type && !selectedAnnotation.value">
+    <label class="col-2  col-form-label" for="annotationValue">Variable </label>
+    <div class="col-10">
+      <div class="form-control">{{selectedAnnotation.variable}}</div>
+      <p class="form-text small-text">Variable that holds the value for a dynamic annotation.</p>
+    </div>
+  </div>
+  <div class="form-group row" *ngIf="selectedAnnotation.type == 'band'">
+    <label class="col-2  col-form-label" for="annotationValue">Width </label>
+    <div class="col-10">
+      <div class="form-control">{{selectedAnnotation.width}}</div>
+      <p class="form-text small-text">Variable that holds the whidth for a band annotation.</p>
+    </div>
+  </div>
+
+  <div class="form-group right-col">
+    <button class="btn btn-col" (click)="cancel()">Close</button>
   </div>
 </div>

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.scss
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.scss
@@ -6,3 +6,11 @@ button.btn.btn-col {
   margin-right: 10px;
   margin-left: 10px;
 }
+
+#annotationAxis {
+  text-transform: uppercase;
+}
+
+#bandNotice {
+  margin-top: 12px;
+}

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/annotations/annotations.component.ts
@@ -12,10 +12,11 @@ import { deepCopy } from '../../../../utils/DeepCopy';
 })
 export class AnnotationsComponent implements OnInit, OnDestroy {
 
-  private selectedAnnotation: Annotation; // selected Annotation for edit
+  private selectedAnnotation: Annotation; // configurated annotation selected by user
   private newAnnotation: Annotation;
   private annotations: Annotation[];
   private annotationId: number = 1;
+  private editConfig: boolean = false; // If false, configuration is shown without edit function
 
   private id: number = null;
 
@@ -62,6 +63,8 @@ export class AnnotationsComponent implements OnInit, OnDestroy {
     if (annotation.variable) {
       annotation.value = undefined;
     }
+    this.editConfig = true;
+    // To prevent it from updating without clicking save button in window
     this.selectedAnnotation = deepCopy(annotation);
   }
 
@@ -69,6 +72,14 @@ export class AnnotationsComponent implements OnInit, OnDestroy {
     annotation.width = Number(annotation.width) ? +annotation.width : annotation.width;
     this.componentsService.update(annotation);
     this.selectedAnnotation = null;
+  }
+
+  showConfiguration(annotation: Annotation): void {
+    if (annotation.variable) {
+      annotation.value = undefined;
+    }
+    this.editConfig = false;
+    this.selectedAnnotation = annotation;
   }
 
   showCreateForm() {

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.html
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.html
@@ -48,12 +48,16 @@
   <thead>
     <tr>
       <th>Type</th>
+      <th>Detail</th>
       <th>Actions</th>
     </tr>
   </thead>
   <tbody>
     <tr *ngFor="let stats of statistics">
       <td>{{stats.type}}</td>
+      <td>
+        <a href="#" (click)="showConfiguration(stats); false">Show</a>
+      </td>
       <td>
         <a href="#" (click)="edit(stats); false">Edit</a>
         <a href="#" (click)="delete(stats); false">Delete</a>
@@ -62,7 +66,7 @@
   </tbody>
 </table>
 
-<div *ngIf="selectedStatistics">
+<div *ngIf="selectedStatistics && editConfig==true">
   <div class="form-group">
     <h3>Edit statistics</h3>
   </div>
@@ -94,5 +98,39 @@
   <div class="form-group right-col">
     <button class="btn btn-col" (click)="update(selectedStatistics)">Save</button>
     <button class="btn btn-col" (click)="cancel()">Cancel</button>
+  </div>
+</div>
+
+<div *ngIf="selectedStatistics && editConfig==false">
+  <div class="form-group">
+    <h3>Configuration</h3>
+  </div>
+
+  <div class="form-group row" *ngIf="selectedStatistics.type == 'confidenceBand'">
+    <label class="col-2  col-form-label" for="statisticsValue">Variable </label>
+    <div class="col-10">
+      <div id="statisticsValue" class="form-control">{{selectedStatistics.variable}}</div>
+      <p class="form-text small-text">Variable that holds the value for a confidence band.</p>
+    </div>
+  </div>
+  <div class="form-group row" *ngIf="selectedStatistics.type == 'confidenceBand'">
+    <label class="col-2  col-form-label" for="statisticsValue">Confidence </label>
+    <div class="col-10">
+      <div id="statisticsValue" class="form-control">{{selectedStatistics.confidence}}</div>
+      <p class="form-text small-text">Variable that holds the confidence interval for a confidence band.</p>
+    </div>
+  </div>
+  <div class="form-group row" *ngIf="selectedStatistics.type == 'confidenceBand'">
+    <label class="col-2  col-form-label" for="statisticsValue">Modifier </label>
+    <div class="col-10">
+      <div id="statisticsValue" class="form-control">{{selectedStatistics.settings}}</div>
+      <p class="form-text small-text">Value that modifies the confidence interval for a confidence band.</p>
+      <p class="form-text small-text">ex)If you input 0.95, confidence = 0.95 * confidence</p>
+      <p class="form-text small-text">(Optional) If you don't want, leave it blank</p>
+    </div>
+  </div>
+
+  <div class="form-group right-col">
+    <button class="btn btn-col" (click)="cancel()">Close</button>
   </div>
 </div>

--- a/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.ts
+++ b/proteus-spring-dashboard/src/app/pages/visualizations/components/statistics/statistics.component.ts
@@ -3,6 +3,7 @@ import { Statistics, StatisticsTypes } from './statistics';
 import { ComponentsService } from '../components.service';
 import { ComponentSet } from '../componentSet';
 import { ActivatedRoute } from '@angular/router';
+import { deepCopy } from '../../../../utils/DeepCopy';
 
 @Component({
   selector: 'app-statistics',
@@ -11,10 +12,11 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class StatisticsComponent implements OnInit, OnDestroy {
 
-  private selectedStatistics: Statistics; // selected statistics for edit
+  private selectedStatistics: Statistics; // configurated statistics selected by user
   private newStatistics: Statistics;
   private statistics: Statistics[];
   private statisticsId: number = 1;
+  private editConfig: boolean = false; // If false, configuration is shown without edit function
 
   private id: number = null;
 
@@ -60,7 +62,9 @@ export class StatisticsComponent implements OnInit, OnDestroy {
   }
 
   edit(statistics: Statistics): void {
-    this.selectedStatistics = statistics;
+    this.editConfig = true;
+    // To prevent it from updating without clicking save button in window
+    this.selectedStatistics = deepCopy(statistics);
   }
 
   update(statistics: Statistics): void {
@@ -69,6 +73,11 @@ export class StatisticsComponent implements OnInit, OnDestroy {
 
     this.componentsService.update(statistics);
     this.selectedStatistics = null;
+  }
+
+  showConfiguration(statistics: Statistics): void {
+    this.editConfig = false;
+    this.selectedStatistics = statistics;
   }
 
   showCreateForm() {


### PR DESCRIPTION
#### What's this PR do?

Add detail window for showing all configuration of annotations, statistics without edit function
(edit function is already made there)

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

---
> Thank you! :heart:

:rocket:

